### PR TITLE
Fix 4.0.0 -> 4.0.1 hdiff link

### DIFF
--- a/GenshinImpact/Client/4.0.0.md
+++ b/GenshinImpact/Client/4.0.0.md
@@ -8,7 +8,7 @@
 
 **[Update | 3.8.0 - 4.0.0](https://d3ln624mszu7ty.cloudfront.net/client_app/update/hk4e_global/10/game_3.8.0_4.0.0_hdiff_Brgs45clx6Teu1wO.zip)**
 
-**[Update | 3.8.0 - 4.0.1](https://d3ln624mszu7ty.cloudfront.net/client_app/update/hk4e_global/10/game_3.8.0_4.0.0_hdiff_Brgs45clx6Teu1wO.zip)**
+**[Update | 3.8.0 - 4.0.1](https://d3ln624mszu7ty.cloudfront.net/client_app/update/hk4e_global/10/game_3.8.0_4.0.0_hdiff_Brgs45clx6Teu1wO.zip)** **[Update | 3.8.0 - 4.0.1 | Old version ](https://d3ln624mszu7ty.cloudfront.net/client_app/update/hk4e_global/10/game_3.8.0_4.0.1_hdiff_h69nuw1XgeJ2qA3i.zip)**
 
 **[Update | 4.0.0 - 4.0.1](https://d3ln624mszu7ty.cloudfront.net/client_app/update/hk4e_global/10/game_4.0.0_4.0.1_hdiff_JNhULRDxB2ntig48.zip)**
 

--- a/GenshinImpact/Client/4.0.0.md
+++ b/GenshinImpact/Client/4.0.0.md
@@ -10,7 +10,7 @@
 
 **[Update | 3.8.0 - 4.0.1](https://d3ln624mszu7ty.cloudfront.net/client_app/update/hk4e_global/10/game_3.8.0_4.0.0_hdiff_Brgs45clx6Teu1wO.zip)**
 
-**[Update | 4.0.0 - 4.0.1](https://d3ln624mszu7ty.cloudfront.net/client_app/update/hk4e_global/10/game_3.8.0_4.0.1_hdiff_h69nuw1XgeJ2qA3i.zip)**
+**[Update | 4.0.0 - 4.0.1](https://d3ln624mszu7ty.cloudfront.net/client_app/update/hk4e_global/10/game_4.0.0_4.0.1_hdiff_JNhULRDxB2ntig48.zip)**
 
 ---
 


### PR DESCRIPTION
someone forgot to update the link lmao

new: `game_4.0.0_4.0.1_hdiff_JNhULRDxB2ntig48`
old: `game_3.8.0_4.0.1_hdiff_h69nuw1XgeJ2qA3i`